### PR TITLE
docs: update testing instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ docker run -p 8000:8000 backend-service
 
 ### Testing
 
-You can test the API endpoints using the provided `test_main.http` file with tools like REST Client for VS Code.
+You can test the API endpoints using the provided `test_app.http` file with tools like REST Client for VS Code.
+
+To run the automated test suite, execute:
+
+```bash
+pytest
+```
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary
- clarify API testing instructions
- add guidance for running pytest test suite

## Testing
- ⚠️ `pytest -q` *(missing httpx dependency; installation failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689cad4a0cb08327bd2bbfcd605f1b61